### PR TITLE
Actually store results in results folder

### DIFF
--- a/packages/server/src/httpServer.js
+++ b/packages/server/src/httpServer.js
@@ -29,7 +29,7 @@ class HttpServer {
       : path.join(this.serverFolderPath, webPath);
     this.logger = new Logger();
     this.downloadData = new DownloadData();
-    this.resultWritter = new ResultWritter(this.serverFolderPath);
+    this.resultWritter = new ResultWritter(path.join(this.serverFolderPath, "results"));
 
     if (!fs.existsSync(this.webFolderPath)) {
       this.logger.error(


### PR DESCRIPTION
A `results` folder is created initially when the server starts up: https://github.com/e7d/speedtest/blob/master/packages/server/server.js#L15-L17

But it's never actually utilized. Thus, attempting to bind `/app/results` to the host in docker does nothing.