### PR TITLE
fix directory traversal issue

### DIFF
--- a/packages/server/src/gzip.js
+++ b/packages/server/src/gzip.js
@@ -22,7 +22,8 @@ function gzip(request, response) {
     writeHead.call(response, myStatusCode, {
       ...myHeaders,
       "Content-Encoding": "gzip",
-      "Content-Length": compressedBuffer.length
+      "Content-Length": compressedBuffer.length,
+      "Content-Security-Policy": "default-src 'self'; img-src 'self' data:"
     });
     write.call(response, compressedBuffer, dataType);
     end.call(response);

--- a/packages/server/src/httpServer.js
+++ b/packages/server/src/httpServer.js
@@ -242,7 +242,7 @@ class HttpServer {
     }
     let filePath = path.join(this.webFolderPath, uri);
     fs.exists(filePath, exists => {
-      if (!exists) {
+      if (!exists || filePath.indexOf(this.webFolderPath) !== 0) {
         response.writeHead(404);
         response.write("Not found");
         response.end();


### PR DESCRIPTION
This PR fixes directory traversal issue, example of attack on demo server:

> $ curl -v --path-as-is http://134.209.196.181:8080/../../../../../../../../../../../../etc/passwd
> *   Trying 134.209.196.181...
> * TCP_NODELAY set
> * Connected to 134.209.196.181 (134.209.196.181) port 8080 (#0)
> > GET /../../../../../../../../../../../../etc/passwd HTTP/1.1
> > Host: 134.209.196.181:8080
> > User-Agent: curl/7.64.1
> > Accept: */*
> >
> < HTTP/1.1 200 OK
> < Content-Type: text/plain
> < Content-Length: 1222
> < Last-Modified: Wed, 10 Feb 2021 08:50:42 GMT
> < Expires: Wed, 17 Feb 2021 08:50:42 GMT
> < Date: Fri, 23 Jul 2021 19:04:55 GMT
> < Connection: keep-alive
> < Keep-Alive: timeout=5
> <
> root:x:0:0:root:/root:/bin/ash
> bin:x:1:1:bin:/bin:/sbin/nologin
> daemon:x:2:2:daemon:/sbin:/sbin/nologin
> adm:x:3:4:adm:/var/adm:/sbin/nologin
> lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
> sync:x:5:0:sync:/sbin:/bin/sync
> shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
> halt:x:7:0:halt:/sbin:/sbin/halt
> mail:x:8:12:mail:/var/mail:/sbin/nologin
> news:x:9:13:news:/usr/lib/news:/sbin/nologin
> uucp:x:10:14:uucp:/var/spool/uucppublic:/sbin/nologin
> operator:x:11:0:operator:/root:/sbin/nologin
> man:x:13:15:man:/usr/man:/sbin/nologin
> postmaster:x:14:12:postmaster:/var/mail:/sbin/nologin
> cron:x:16:16:cron:/var/spool/cron:/sbin/nologin
> ftp:x:21:21::/var/lib/ftp:/sbin/nologin
> sshd:x:22:22:sshd:/dev/null:/sbin/nologin
> at:x:25:25:at:/var/spool/cron/atjobs:/sbin/nologin
> squid:x:31:31:Squid:/var/cache/squid:/sbin/nologin
> xfs:x:33:33:X Font Server:/etc/X11/fs:/sbin/nologin
> games:x:35:35:games:/usr/games:/sbin/nologin
> cyrus:x:85:12::/usr/cyrus:/sbin/nologin
> vpopmail:x:89:89::/var/vpopmail:/sbin/nologin
> ntp:x:123:123:NTP:/var/empty:/sbin/nologin
> smmsp:x:209:209:smmsp:/var/spool/mqueue:/sbin/nologin
> guest:x:405:100:guest:/dev/null:/sbin/nologin
> nobody:x:65534:65534:nobody:/:/sbin/nologin
> node:x:1000:1000:Linux User,,,:/home/node:/bin/sh
> * Connection #0 to host 134.209.196.181 left intact
> * Closing connection 0